### PR TITLE
UNI-31 Add new docker images for CodeBuild.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .history/
+.idea/
+

--- a/Node10/Dockerfile
+++ b/Node10/Dockerfile
@@ -13,6 +13,6 @@ RUN apk add --no-cache \
 
 ENV NODE_ENV development
 
-RUN yarn global add serverless@1.51.0
+RUN npm install -g serverless@1.51.0
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/Node12/Dockerfile
+++ b/Node12/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:12-alpine
+
+RUN apk add --no-cache \
+  python \
+  py-pip \
+  py-setuptools \
+  ca-certificates \
+  build-base \
+  groff \
+  less \
+  bash && \
+  pip install --no-cache-dir --upgrade pip awscli
+
+ENV NODE_ENV development
+
+RUN npm install -g serverless@1.51.0
+
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/Node14/Dockerfile
+++ b/Node14/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:14-alpine
+
+RUN apk add --no-cache \
+  python \
+  py-pip \
+  py-setuptools \
+  ca-certificates \
+  build-base \
+  groff \
+  less \
+  bash && \
+  pip install --no-cache-dir --upgrade pip awscli
+
+ENV NODE_ENV development
+
+RUN npm install -g serverless@2.48.0
+
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This image is based on node:12-alpine ([AWS Lambda uses Node v12.x](http://docs.
 
 To deploy a Serverless service to AWS you will need to create an IAM user with the required permissions and set credentials. I'm setting credentials using [Bitbucket Pipelines environment variables](https://confluence.atlassian.com/bitbucket/environment-variables-in-bitbucket-pipelines-794502608.html); however setting credentials in Dockerfile is also possible.
 
-# install commands
+# Install commands
 
 Use the following steps to authenticate and push an image to your repository. For additional registry authentication methods, including the Amazon ECR credential helper, see [Registry Authentication](http://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth) .
 


### PR DESCRIPTION
We were having conflicts using yarn to install dependencies on build time, so we decided to remove it and just use npm. In order to avoid issues with the existing working projects, we decided to push the new Docker versions to a different repository in the AWS accounts.  923195502435.dkr.ecr.us-east-1.amazonaws.com/blink-node-serverless